### PR TITLE
load_document: Lower priority of HTML inputs

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -6568,10 +6568,10 @@ def load_document(url,
     :return: True if the value is an absolute IRI, False if not.
     """
     headers = {
-        'Accept': 'application/ld+json, application/json;q=0.5'
+        'Accept': 'application/ld+json, application/json;q=0.8'
     }
     # FIXME: only if html5lib loaded?
-    headers['Accept'] = headers['Accept'] + ', text/html;q=0.8, application/xhtml+xml;q=0.8'
+    headers['Accept'] = headers['Accept'] + ', text/html;q=0.5, application/xhtml+xml;q=0.5'
 
     if requestProfile:
         headers['Accept'] = ('application/ld+json;profile=%s, ' % requestProfile) + headers['Accept']


### PR DESCRIPTION
This fixes a bug with activitypub related documents: The schema "https://www.w3.org/ns/activitystreams" renders the spec if "application/json" has a lower prioritisation than "text/html".